### PR TITLE
Cleanup of python 2.6 from travis and older buildout parts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
 install:
   - pip install -r requirements.txt

--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Hostname: 0.0.0.0
 Port: 8080
 2013-03-22 13:58:44 INFO Zope Ready to handle requests
 ```
-Adds to the buildout development scripts (`test`, `i18ndude`) and to plone some
+Adds to the buildout development scripts (`test`) and to plone some
 products (`plone.reload` and `stxnext.pdb`).
 Some other are suggested (commented) In the `profiles/development.cfg` file.
 Ask for new stuff if you want (`sauna.reload`, `plone.app.debugtoolbar`, ...).

--- a/config/development.cfg
+++ b/config/development.cfg
@@ -23,25 +23,11 @@ eggs+=
 zcml+=
     stxnext.pdb
 
-# create bin/i18ndude command
-[i18ndude]
-unzip = true
-recipe = zc.recipe.egg
-eggs = i18ndude
-
 # create bin/test command
 [test]
 recipe = zc.recipe.testrunner
 defaults = ['--auto-color', '--auto-progress']
 eggs =
-    ${instance-settings:eggs}
-
-# create ZopeSkel command
-[zopeskel]
-unzip = true
-recipe = zc.recipe.egg
-eggs =
-    ZopeSkel
     ${instance-settings:eggs}
 
 [omelette]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 setuptools==26.1.1
 wheel==0.29.0
-zc.buildout==2.5.3
+zc.buildout==2.9.5
 mr.bob
 bobtemplates.plone


### PR DESCRIPTION
Removed unused zopeskel and i18ndude parts from dev buildout.
Removed python2.6 test from travis.
Solves #14 